### PR TITLE
🔨: direct 접근했을 때 데이터가 안뜨는 것 수정

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,12 +9,14 @@ const bodyParser = require('body-parser');
 
 const index = require('./routes/index');
 const card = require('./routes/card');
+const life = require('./routes/life');
+const bible = require('./routes/bible');
 
 const app = express();
 const port = process.env.PORT || 6508;
 
-// var redirectToHTTPS = require('express-http-to-https').redirectToHTTPS
-// app.use(redirectToHTTPS([/13.209.190.90/]));
+var redirectToHTTPS = require('express-http-to-https').redirectToHTTPS
+app.use(redirectToHTTPS([/13.209.190.90/]));
 app.use(function(req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
   res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
@@ -45,6 +47,8 @@ mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true })
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', index);
 app.use('/card', card);
+app.use('/bible', bible);
+app.use('/life', life);
 
 app.listen(port, function (){
   console.log(`Server running port ${port}`)

--- a/backend/routes/bible.js
+++ b/backend/routes/bible.js
@@ -1,0 +1,10 @@
+var express = require('express');
+var path = require('path');
+var router = express.Router();
+
+/* GET home page. */
+router.get('/', function(req, res, next) {
+  res.sendFile(path.join(__dirname, '..','public', 'index.html'))
+});
+
+module.exports = router;

--- a/backend/routes/life.js
+++ b/backend/routes/life.js
@@ -1,0 +1,10 @@
+var express = require('express');
+var path = require('path');
+var router = express.Router();
+
+/* GET home page. */
+router.get('/', function(req, res, next) {
+  res.sendFile(path.join(__dirname, '..','public', 'index.html'))
+});
+
+module.exports = router;


### PR DESCRIPTION
이건 그냥 라우터를 박아놓고 거기에 / 페이지는 index.html이 뜨도록 해놓으면 됩니다.
이유는 /bible이나 /life로 바로 접근한경우 /의 것을 못불러옵니다. 그래서 각각의 라우터를 만들어서 index.html을 불러줘야합니다.